### PR TITLE
Register functions functionality

### DIFF
--- a/hither2/__init__.py
+++ b/hither2/__init__.py
@@ -17,3 +17,6 @@ from .computeresource import ComputeResource
 from .database import Database
 from .jobcache import JobCache
 from .file import File
+
+# Run a function by name
+from .core import run

--- a/hither2/core.py
+++ b/hither2/core.py
@@ -265,7 +265,7 @@ _global_registered_functions_by_name = dict()
 
 # run a registered function by name
 def run(function_name, **kwargs):
-    assert function_name in _global_registered_functions_by_name, 'Hither function {function_name} not registered'
+    assert function_name in _global_registered_functions_by_name, f'Hither function {function_name} not registered'
     f = _global_registered_functions_by_name[function_name]
     return f.run(**kwargs)
 

--- a/tests/functions/__init__.py
+++ b/tests/functions/__init__.py
@@ -25,6 +25,6 @@ functions = SimpleNamespace(
     bad_container=bad_container,
     additional_file=additional_file,
     local_module=local_module,
-    identity=identity
+    identity=identity2
 )
 

--- a/tests/functions/__init__.py
+++ b/tests/functions/__init__.py
@@ -11,7 +11,7 @@ from .do_nothing import do_nothing
 from .bad_container import bad_container
 from .additional_file import additional_file
 from .local_module import local_module
-from .identity import identity
+from .identity import identity2
 
 functions = SimpleNamespace(
     zeros=zeros,

--- a/tests/functions/identity.py
+++ b/tests/functions/identity.py
@@ -2,9 +2,9 @@ import os
 import hither2 as hi
 import numpy as np
 
-@hi.function('identity', '0.1.1')
+@hi.function('identity2', '0.1.1')
 @hi.container('docker://jupyter/scipy-notebook:678ada768ab1')
-def identity(x):
+def identity2(x):
     if type(x) == str:
         if x.startswith('/') and os.path.exists(x):
             return hi.File(x)
@@ -13,12 +13,12 @@ def identity(x):
     elif type(x) == dict:
         ret = dict()
         for key, val in x.items():
-            ret[key] = identity(val)
+            ret[key] = identity2(val)
         return ret
     elif type(x) == list:
-        return [identity(a) for a in x]
+        return [identity2(a) for a in x]
     elif type(x) == tuple:
-        return tuple([identity(a) for a in x])
+        return tuple([identity2(a) for a in x])
     else:
         return x
 
@@ -39,4 +39,4 @@ def test_calls():
         ]
     ]
 
-identity.test_calls = test_calls
+identity2.test_calls = test_calls

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -87,6 +87,10 @@ def test_run_functions(general):
     with hi.config(container=False):
         do_test_run_functions()
 
+def test_run_function_by_name(general):
+    x = hi.run('add', x=1, y=2).wait()
+    assert x is 3
+
 @pytest.mark.container
 def test_run_functions_in_container(general):
     with hi.config(container=True, job_handler=hi.ParallelJobHandler(num_workers=20)):

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -26,7 +26,7 @@ def test_remote_1b(general, mongodb, kachery_server, compute_resource):
         assert np.array_equal(a, np.ones((4, 3)))
         assert jh._internal_counts.num_jobs == 2, f'Unexpected number of jobs: {jh._internal_counts.num_jobs}'
 
-# @pytest.mark.remote
+@pytest.mark.remote
 def test_remote_2(general, mongodb, kachery_server, compute_resource):
     db = hi.Database(mongo_url=f'mongodb://localhost:{MONGO_PORT}', database=DATABASE_NAME)
     jh = hi.RemoteJobHandler(database=db, compute_resource_id=COMPUTE_RESOURCE_ID)


### PR DESCRIPTION
The purpose is to add functionality of running a function by name. When a hither function is decorated, it is added to a registry. That allows calling run by name in the following way

```
hi.run('function_name', arg1=val1, arg2=val2)
```

equivalent to:

```
function_name.run(arg1=val1, arg2=val2)
```

This is important for being able to call hither functions from within javascript/react.