### PR TITLE
PR 18 patch

### DIFF
--- a/hither2/_Config.py
+++ b/hither2/_Config.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from enum import Enum
 from typing import Any, Deque, Dict, Union
 from .jobcache import JobCache
+from ._basejobhandler import BaseJobHandler
 
 class Inherit(Enum):
     INHERIT = ''
@@ -13,7 +14,7 @@ class Config:
 
     def __init__(self,
         container: Union[str, bool, Inherit, None]=Inherit.INHERIT,
-        job_handler: Any=Inherit.INHERIT, # TODO: ABC
+        job_handler: Union[BaseJobHandler, Inherit]=Inherit.INHERIT,
         job_cache: Union[JobCache, Inherit, None]=Inherit.INHERIT,
         download_results: Union[bool, Inherit, None]=Inherit.INHERIT,
         job_timeout: Union[float, Inherit, None]=Inherit.INHERIT

--- a/hither2/__init__.py
+++ b/hither2/__init__.py
@@ -8,7 +8,7 @@ from ._shellscript import ShellScript
 from ._filelock import FileLock
 from ._consolecapture import ConsoleCapture
 from .core import _deserialize_job
-from ._util import _serialize_item, _deserialize_item, _replace_values_in_structure
+from ._util import _serialize_item, _deserialize_item, _copy_structure_with_changes
 from .defaultjobhandler import DefaultJobHandler
 from .paralleljobhandler import ParallelJobHandler
 from .slurmjobhandler import SlurmJobHandler

--- a/hither2/__init__.py
+++ b/hither2/__init__.py
@@ -1,5 +1,5 @@
 from .core import function, container, additional_files, local_modules, opts
-from .core import Config, set_config
+from .core import Config
 from .core import wait
 from .core import reset
 from ._identity import identity

--- a/hither2/_run_serialized_job_in_container.py
+++ b/hither2/_run_serialized_job_in_container.py
@@ -18,6 +18,7 @@ def _run_serialized_job_in_container(job_serialized):
         label = name
     show_console = True
     gpu = False
+    # This variable is reserved for future use
     timeout: Union[None, float] = None
     
     code = job_serialized['code']
@@ -235,11 +236,12 @@ def _run_serialized_job_in_container(job_serialized):
                 if retcode is not None:
                     break
                 elapsed = time.time() - timer
-                if timeout is not None:
-                    if elapsed > timeout:
-                        print(f'Stopping job due to timeout {elapsed} > {timeout}')
-                        did_timeout = True
-                        ss.stop()
+                # TODO: this code is currently unreachable but should be uncommented when `timeout` is used.
+                # if timeout is not None:
+                #     if elapsed > timeout:
+                #         print(f'Stopping job due to timeout {elapsed} > {timeout}')
+                #         did_timeout = True
+                #         ss.stop()
         finally:
             if docker_container_name is not None:
                 ss_cleanup = ShellScript(f"""

--- a/hither2/_run_serialized_job_in_container.py
+++ b/hither2/_run_serialized_job_in_container.py
@@ -67,7 +67,7 @@ def _run_serialized_job_in_container(job_serialized):
 
                 if ok_import_hither2:
                     from hither2 import ConsoleCapture
-                    from hither2 import _deserialize_item, _serialize_item, _replace_values_in_structure
+                    from hither2 import _deserialize_item, _serialize_item, _copy_structure_with_changes
                     from hither2 import File
 
                     kwargs = json.loads('{kwargs_json}')
@@ -77,10 +77,10 @@ def _run_serialized_job_in_container(job_serialized):
                         try:
                             from function_src import {function_name}
                             if not {no_resolve_input_files}:
-                                kwargs = _replace_values_in_structure(kwargs,
-                                    lambda arg: arg.resolve() if isinstance(arg, File) else arg)
+                                kwargs = _copy_structure_with_changes(kwargs,
+                                    lambda arg: arg.resolve(), _type = File)
                             retval = {function_name}(**kwargs)
-                            retval = _replace_values_in_structure(retval, File.kache_numpy_array)
+                            retval = _copy_structure_with_changes(retval, File.kache_numpy_array)
                             success = True
                             error = None
                         except Exception as e:

--- a/hither2/_shellscript.py
+++ b/hither2/_shellscript.py
@@ -239,7 +239,6 @@ def _rmdir_with_retries(dirname, num_retries, delay_between_tries=1):
             else:
                 raise Exception('Unable to remove directory after {} tries: {}'.format(num_retries, dirname))
 
-# TODO: Move these tests into test directory?
 def _test_error_handling_1():
     import pytest
     with pytest.raises(Exception):

--- a/hither2/_util.py
+++ b/hither2/_util.py
@@ -92,12 +92,18 @@ def _random_string(num: int):
     return ''.join(random.choices('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', k=num))
 
 def _flatten_nested_collection(item: Any, _type: Union[Any, None] = None) -> List[Any]:
-    """Return a single list of the base items in a nested data structure consisting of an
-    arbitrary combination of dicts, lists, and tuples.s
+    """Flattens the input data structure, returning a list of only the content (non-dict,
+    list, or tuple) elements.
 
     Arguments:
-        item {Any} -- (Potentially arbitrarily) nested data structure to flatten. May contain
-        base items and sub-collections at the same level.
+        item {Any} -- A data structure consisting of [0..n) elements, each of which may be
+        a list, dict, or tuple ("collection elements"), or a "content element." Collection
+        elements may be nested to any depth, and may contain both collection elements and
+        content elements at the same level.
+
+    Keyword Arguments:
+        _type {Union[Any, None]} -- If set, filter the content elements so that only those
+        matching the input type are returned. (default: {None})
 
     Returns:
         List[Any] -- Every content (leaf) item of the input structure.
@@ -119,6 +125,7 @@ def _flatten_nested_collection(item: Any, _type: Union[Any, None] = None) -> Lis
         # (which is read as "return `value`, for i in item: for value in _fnc(i):")
     return elements
 
+# TODO: REWRITE THIS to return a duplicate structure rather than mutating in-place.
 def _replace_values_in_structure(structure: Any, replacement_function: Callable[..., Any]) -> Any:
     """Modify values of input data structure in place, according to function.
 

--- a/hither2/_util.py
+++ b/hither2/_util.py
@@ -125,32 +125,58 @@ def _flatten_nested_collection(item: Any, _type: Union[Any, None] = None) -> Lis
         # (which is read as "return `value`, for i in item: for value in _fnc(i):")
     return elements
 
-# TODO: REWRITE THIS to return a duplicate structure rather than mutating in-place.
-def _replace_values_in_structure(structure: Any, replacement_function: Callable[..., Any]) -> Any:
-    """Modify values of input data structure in place, according to function.
+def _copy_structure_with_changes(structure: Any, replacement_function: Callable[..., Any],
+        _as_side_effect:bool = False,
+        _type: Union[Any, None] = None) -> Any:
+    """Create a copy of the input data structure, with certain values modified by <replacement_function>.
+    Note that care must be taken to keep a separate reference to the original data structure if you
+    wish to keep it as well as the replacement. Additionally, objects in <structure> are not
+    deep-copied, so if <replacement_function> makes a modification to an object in <structure>,
+    the original reference will still point to the modified object.
 
     Arguments:
         structure {Any} -- Structure to be modified (dict, list, nested dicts...)
         replacement_function {Callable[..., Any]} -- Function which applies mutations to
-        the elements of <structure> and returns a new value to be stored in the original
-        data structure. This function should perform whatever type inspection is necessary
-        to ensure it only operates on specific types, and should return, unmodified, any
-        values which it does not operate on.
+        the elements of <structure> and returns a new value. If the <_type> parameter is not
+        set, this function must perform whatever type inspection is necessary to ensure
+        it only operates on specific types and return without modification any
+        values of types it does not operate on.
+
+    Keyword Arguments:
+        _as_side_effect {bool} -- If True, we assume that <replacement_function> will be called
+        for its side effects (perhaps by calling a method on an object that does not have any
+        return of its own), and so will return the original value of its target even if the
+        target is of the selected type. For instance, in a replacement function of the form
+        'lambda x: x.copy_to_server()' (where the method `copy_to_server(self)` causes self
+        to take some action but does not return self), setting <_as_side_effect> ensures that
+        the value of `x` appears in the returned data structure; if <_as_side_effect> were
+        set to False, then the return of `x.copy_to_server()` would be used, resulting in
+        the object being replaced with None in the copied structure. (default: {False})
+
+        _type {Union[Any, None]} -- If set, only elements of the matching type will be passed
+        to <replacement_function>; others will be put into place unmodified. (default: {None})
 
     Returns:
-        Any -- The original structure, as modified in-place.
+        Any -- A copy of the original data structure, with modifications.
     """
     entrytype = type(structure)
+    copy = None
     # ignore cases where there is no data structure to modify
     if entrytype not in [dict, list, tuple]:
+        if _type is not None and not isinstance(structure, _type):
+            return structure
+        if _as_side_effect:
+            replacement_function(structure)
+            return structure
         return replacement_function(structure)
     if entrytype == dict:
+        copy = {}
         for k, v in structure.items():
-            structure[k] = _replace_values_in_structure(v, replacement_function)
+            copy[k] = _copy_structure_with_changes(v, replacement_function, _type=_type)
+        return copy
     elif entrytype == list:
-        structure = [_replace_values_in_structure(v, replacement_function) for v in structure]
+        return [_copy_structure_with_changes(v, replacement_function, _type=_type) for v in structure]
     elif entrytype == tuple:
-        structure = tuple([_replace_values_in_structure(v, replacement_function) for v in structure])
-    return structure
+        return tuple([_copy_structure_with_changes(v, replacement_function, _type=_type) for v in structure])
 
 

--- a/hither2/core.py
+++ b/hither2/core.py
@@ -22,39 +22,6 @@ _default_global_config = dict(
 )
 
 Config.set_default_config(_default_global_config)
-
-
-# TODO: QUERY: Is this functionality needed, can we remove it entirely? Or do we need to support it
-# in the rewrite of configuration
-def set_config(
-        container: Union[str, bool, None]=None,
-        job_handler: Any=None,
-        job_cache: Union[JobCache, None]=None,
-        download_results: Union[bool, None]=None,
-        job_timeout: Union[float, None]=None
-) -> None:
-    """Set hither2 configuration parameters.
-    
-    Usually you will want to instead use the context manager
-    form of this function:
-    ```
-    with hi.Config(...):
-        ...
-    ```
-    See help for the `config` function.
-    Any parameter that is left as the default None
-    will not be modified.
-    """
-    # _global_config.set_config(
-    #     container=container,
-    #     job_handler=job_handler,
-    #     job_cache=job_cache,
-    #     download_results=download_results,
-    #     job_timeout=job_timeout
-    # )
-    pass
-
-
 _global_job_manager = _JobManager()
 
 def reset():

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -35,8 +35,8 @@ def test_call_functions_directly(general):
                 if not test_call.get('container_only'):
                     args = test_call.get('args')
                     # the following is needed for the case where we send in a hi.File object
-                    args = hi._replace_values_in_structure(args,
-                        lambda r: r.resolve() if isinstance(r, hi.File) else r)
+                    args = hi._copy_structure_with_changes(args, lambda r: r.resolve(), _type = hi.File,
+                        _as_side_effect  = False)
                     print(f'Calling {function.__name__} {args}')
                     try:
                         result = function(**args)


### PR DESCRIPTION
A couple points had been raised in comments to PR 18 that I didn't see until after it was merged. I've addressed them below.

By far the biggest deal with this PR was changing the function-mapping procedure (now `_copy_structure_with_changes` in `_util.py`) to return a copy instead of changing in place. I've made the method a good deal more robust, and it now returns a copy of any input data structure; however, do note that 1) the caller needs to maintain a separate reference to that data structure, or it'll just get garbage-collected; 2) we are **not** deep-copying the objects in the data structure, so any calls that change the underlying object are going to change it, even if it's being accessed with the reference from the original data structure.

The parameter to apply side effects is a bit tricky. As is I don't have a specific case where I'm using it, but I didn't realize that until it was actually implemented... I have tested it in some trivial cases in an interactive terminal, but as it isn't used in the present code base it is obviously outside the visibility of our existing tests.